### PR TITLE
fix postfix installation (stops because of hostname)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:21.10
 
 MAINTAINER antespi@gmail.com
 
@@ -13,6 +13,10 @@ RUN set -x; \
     && DEBIAN_FRONTEND=noninteractive apt-get upgrade -y \
     && echo "postfix postfix/mailname string $MAILNAME" | debconf-set-selections \
     && echo "postfix postfix/main_mailer_type string 'Internet Site'" | debconf-set-selections \
+    && hn=$(grep $(hostname) /etc/hosts | cut -f1) \
+    && cp /etc/hosts /etc/hosts2 && sed -i '$ d' /etc/hosts2 && cp /etc/hosts2 /etc/hosts \
+    && echo $hn $MAILNAME >> /etc/hosts \
+    && echo $MAILNAME > /etc/hostname \
     && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
         postfix \
         dovecot-core \
@@ -24,13 +28,11 @@ RUN set -x; \
     && rm -rf /var/cache/apt/archives/* /var/cache/apt/*.bin /var/lib/apt/lists/* \
     && rm -rf /usr/share/man/* && rm -rf /usr/share/doc/* \
     && touch /var/log/auth.log \
-
     # Create mail user
     && adduser $MAIL_FS_USER --home $MAIL_FS_HOME --shell /bin/false --disabled-password --gecos "" \
     && chown -R ${MAIL_FS_USER}: $MAIL_FS_HOME \
     && usermod -aG $MAIL_FS_USER postfix \
     && usermod -aG $MAIL_FS_USER dovecot \
-
     && echo "Installed: OK"
 
 ADD postfix /etc/postfix


### PR DESCRIPTION
Output of mail.log:

```
Running newaliases
newaliases: warning: valid_hostname: misplaced delimiter: fe4776b94017..
newaliases: fatal: file /etc/postfix/main.cf: parameter myhostname: bad parameter value: fe4776b94017..
dpkg: error processing package postfix (--configure):
 subprocess installed post-installation script returned error exit status 75
...
Errors were encountered while processing:
 postfix
E: Sub-process /usr/bin/dpkg returned an error code (1)
```
fe4776b94017 is an example hostname created by docker.
To change the hostname I used [this documentation](https://unix.stackexchange.com/questions/404189/find-and-sed-string-in-docker-got-error-device-or-resource-busy)

Removed some blank lines because docker is [complaining](https://stackoverflow.com/questions/46708053/empty-continuation-lines-will-become-errors-how-should-i-comment-my-dockerfil)