### PR TITLE
Disable TLS support from postfix handshake "capabilities"

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -128,6 +128,9 @@ _add_line "$DEBUG_ADDRESS" "/.+@.+/ $DEBUG_ADDRESS" /etc/postfix/virtual_regexp
 /usr/sbin/postmap /etc/postfix/vmailbox
 /usr/sbin/postmap /etc/postfix/sender_canonical_regexp
 
+# Disable TLS when using only port 25
+/usr/sbin/postconf -e smtpd_use_tls=no
+
 # Configuring Dovecot
 cp -a /usr/share/dovecot/protocols.d /etc/dovecot/
 sed -i -e 's/include_try \/usr\/share\/dovecot\/protocols\.d/include_try \/etc\/dovecot\/protocols\.d/g' /etc/dovecot/dovecot.conf


### PR DESCRIPTION
I came across a problem where `postfix` would return with STARTTLS as an option that it could support. As port 25 is the only used port on the project, applications (Laravel in my case) can get confused and try to negotiate TLS over plaintext. 

**Before:**


```
Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream {#323 ▼
  #stream: &1 stream resource @11 ▶}
  #in: &1 stream resource @11
  #out: &1 stream resource @11
  -debug: """
    < 220 b89d1fe2f359 ESMTP Postfix (Ubuntu)
    > EHLO [127.0.0.1]
    < 250-b89d1fe2f359
    < 250-PIPELINING
    < 250-SIZE 10240000
    < 250-VRFY
    < 250-ETRN
    < 250-STARTTLS                  ## Problem Child
    < 250-ENHANCEDSTATUSCODES
    < 250-8BITMIME
    < 250-DSN
    < 250 SMTPUTF8
    """
  -url: "imap:25"
  -host: "imap"
  -port: 25
  -tls: false
  -sourceIp: null
  -streamContextOptions: []
}
```

**After:**

```
^ Symfony\Component\Mailer\Transport\Smtp\Stream\SocketStream {[#323 ▼]()
  #stream: [&1]stream resource [@11 ▶]
  #in: [&1]stream resource [@11]
  #out: [&1]stream resource [@11]
  -debug: """
    < 220 30aaa82497e9 ESMTP Postfix (Ubuntu)

    > EHLO [127.0.0.1]
    < 250-30aaa82497e9
    < 250-PIPELINING
    < 250-SIZE 10240000
    < 250-VRFY
    < 250-ETRN
    < 250-ENHANCEDSTATUSCODES
    < 250-8BITMIME
    < 250-DSN
    < 250 SMTPUTF8
    """
  -url: "imap:25"
  -host: "imap"
  -port: 25
  -tls: false
  -sourceIp: null
  -streamContextOptions: []
}
```